### PR TITLE
fix the endpoint, fix the limit upload, util to push he image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 node_modules/
 dist/
 .env
+.env.*
+!.env.example
 __pycache__/
 *.pyc
 venv/
 *.db
 .DS_Store
 images/
+*.pem

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ docker compose up --build
 
 ```bash
 cd frontend
+cp .env.example .env.development
+# Edit .env.development with your what3words API key
 npm install
 npm run dev
 ```
@@ -93,6 +95,119 @@ npm run api:generate
 ```
 
 Generated files live in `frontend/src/api/` and should not be edited by hand.
+
+## Frontend Environment
+
+The frontend uses Vite environment files to configure the API URL:
+
+- `.env.development` — used during `npm run dev`, points to `http://localhost:8000`
+- `.env.production` — used during `npm run build`, points to `https://api.mapthemess.uk`
+
+The `VITE_API_URL` variable controls which API base URL the frontend talks to. Vite bakes this in at build time.
+
+## Production Deployment
+
+### Pushing Docker images
+
+Run the script from the project root:
+
+```bash
+./push-images.sh
+```
+
+This builds, tags, and pushes the frontend and backend images to Docker Hub under `max246/map-the-mess-backend` and `max246/map-the-mess-frontend`.
+
+### Deploying on EC2
+
+1. Copy `docker-compose.prod.yml`, the `proxy-conf/` directory, and your `.env` file to the EC2 instance.
+
+2. Install Docker and Docker Compose:
+
+   ```bash
+   sudo yum install -y docker
+   sudo systemctl enable --now docker
+   sudo usermod -aG docker $USER
+   # Log out and back in
+   sudo mkdir -p /usr/local/lib/docker/cli-plugins
+   sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+     -o /usr/local/lib/docker/cli-plugins/docker-compose
+   sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+   ```
+
+3. Start the services:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml up -d
+   ```
+
+### DNS (Route 53)
+
+Add two A records in AWS Route 53 pointing to your EC2 Elastic IP:
+
+| Type | Name                | Value          |
+|------|---------------------|----------------|
+| A    | `mapthemess.uk`     | EC2 Elastic IP |
+| A    | `api.mapthemess.uk` | EC2 Elastic IP |
+
+### SSL (Let's Encrypt)
+
+SSL is handled automatically by the `nginx-proxy` and `acme-companion` containers in `docker-compose.prod.yml`. Certificates are requested and renewed automatically for both `mapthemess.uk` and `api.mapthemess.uk`.
+
+### EC2 Security Group
+
+Ensure inbound rules allow:
+
+| Port | Protocol | Source     |
+|------|----------|------------|
+| 80   | TCP      | 0.0.0.0/0 |
+| 443  | TCP      | 0.0.0.0/0 |
+
+### Nginx proxy config
+
+Custom per-host Nginx settings live in `proxy-conf/`. The file `proxy-conf/api.mapthemess.uk` sets `client_max_body_size 50m` for the API to allow image uploads. This file is bind-mounted into the `nginx-proxy` container.
+
+### Architecture
+
+```
+                    ┌─────────────────┐
+                    │   nginx-proxy   │ ← ports 80/443, SSL termination
+                    │ + acme-companion│ ← auto Let's Encrypt certs
+                    └────────┬────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │                             │
+    mapthemess.uk               api.mapthemess.uk
+              │                             │
+     ┌────────▼────────┐          ┌─────────▼─────────┐
+     │    frontend     │          │     backend        │
+     │  (nginx + SPA)  │          │   (FastAPI:8000)   │
+     └─────────────────┘          └─────────┬──────────┘
+                                            │
+                                   ┌────────▼────────┐
+                                   │   db (postgres)  │
+                                   └─────────────────┘
+```
+
+### Updating the deployment
+
+After pushing new images:
+
+```bash
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
+```
+
+To fully recreate containers (e.g. after config changes):
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --force-recreate
+```
+
+To clean up old images on EC2:
+
+```bash
+docker system prune -a -f
+```
 
 ## Contributing
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -57,7 +57,12 @@ app = FastAPI(
 # CORS — allow frontend dev server
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=[
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "https://mapthemess.uk",
+        "http://mapthemess.uk",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,71 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5433:5432"
+
+  backend:
+    image: max246/map-the-mess-backend:latest
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      SECRET_KEY: ${SECRET_KEY}
+      SUPERUSER_EMAIL: ${SUPERUSER_EMAIL}
+      SUPERUSER_PASSWORD: ${SUPERUSER_PASSWORD}
+      SUPERUSER_FULL_NAME: ${SUPERUSER_FULL_NAME:-Super User}
+      VIRTUAL_HOST: api.mapthemess.uk
+      VIRTUAL_PORT: "8000"
+      LETSENCRYPT_HOST: api.mapthemess.uk
+    depends_on:
+      - db
+
+  frontend:
+    image: max246/map-the-mess-frontend:latest
+    restart: unless-stopped
+    environment:
+      VIRTUAL_HOST: mapthemess.uk
+      VIRTUAL_PORT: "80"
+      LETSENCRYPT_HOST: mapthemess.uk
+    depends_on:
+      - backend
+
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - certs:/etc/nginx/certs
+      - vhost:/etc/nginx/vhost.d
+      - ./proxy-conf/api.mapthemess.uk:/etc/nginx/vhost.d/api.mapthemess.uk:ro
+      - html:/usr/share/nginx/html
+    environment:
+      TRUST_DOWNSTREAM_PROXY: "false"
+      CLIENT_MAX_BODY_SIZE: "50m"
+
+  acme-companion:
+    image: nginxproxy/acme-companion:latest
+    restart: unless-stopped
+    volumes_from:
+      - nginx-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - acme:/etc/acme.sh
+    environment:
+      DEFAULT_EMAIL: ${SUPERUSER_EMAIL}
+
+volumes:
+  pgdata:
+  certs:
+  vhost:
+  html:
+  acme:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_W3W_API_KEY=your_what3words_api_key
+VITE_API_URL=http://localhost:8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 
 # Production stage

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,6 +3,8 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    client_max_body_size 50m;
+
     # Proxy API requests to the backend
     location /api/ {
         proxy_pass http://backend:8000;

--- a/frontend/orval.config.ts
+++ b/frontend/orval.config.ts
@@ -9,6 +9,13 @@ export default defineConfig({
       client: "axios",
       mode: "tags-split",
       clean: true,
+      override: {
+        mutator: {
+          path: "./src/api/client.js",
+          name: "customInstance",
+        },
+      },
+
     },
   },
 });

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,8 +1,14 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: import.meta.env.VITE_API_URL || '',
   timeout: 10000
 })
 
 export default api
+
+export const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+
+export const customInstance = (config) => {
+  return api(config).then((response) => response.data)
+}

--- a/frontend/src/api/endpoints/auth/auth.ts
+++ b/frontend/src/api/endpoints/auth/auth.ts
@@ -5,13 +5,6 @@
  * Backend for the community litter reporting platform
  * OpenAPI spec version: 0.1.0
  */
-import axios from 'axios';
-import type {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
-
 import type {
   ForgotPassword,
   ResetPassword,
@@ -22,94 +15,112 @@ import type {
   UserUpdateType
 } from '../../model';
 
+import { customInstance } from '../../client';
 
 
 
-  export const getAuth = (axiosInstance: AxiosInstance = axios) => {
+  export const getAuth = () => {
 /**
  * List all users. Requires admin access.
  * @summary List Users
  */
 const listUsersApiAuthUsersGet = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<UserRead[]>> => {
-    return axiosInstance.get(
-      `/api/auth/users`,options
-    );
-  }
-/**
+    
+ ) => {
+      return customInstance<UserRead[]>(
+      {url: `/api/auth/users`, method: 'GET'
+    },
+      );
+    }
+  /**
  * @summary Register
  */
 const registerApiAuthRegisterPost = (
-    userCreate: UserCreate, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<UserRead>> => {
-    return axiosInstance.post(
-      `/api/auth/register`,
-      userCreate,options
-    );
-  }
-/**
+    userCreate: UserCreate,
+ ) => {
+      return customInstance<UserRead>(
+      {url: `/api/auth/register`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: userCreate
+    },
+      );
+    }
+  /**
  * @summary Login
  */
 const loginApiAuthLoginPost = (
-    userLogin: UserLogin, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<Token>> => {
-    return axiosInstance.post(
-      `/api/auth/login`,
-      userLogin,options
-    );
-  }
-/**
+    userLogin: UserLogin,
+ ) => {
+      return customInstance<Token>(
+      {url: `/api/auth/login`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: userLogin
+    },
+      );
+    }
+  /**
  * @summary Update User Type
  */
 const updateUserTypeApiAuthUsersUserIdTypePatch = (
     userId: number,
-    userUpdateType: UserUpdateType, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<UserRead>> => {
-    return axiosInstance.patch(
-      `/api/auth/users/${userId}/type`,
-      userUpdateType,options
-    );
-  }
-/**
+    userUpdateType: UserUpdateType,
+ ) => {
+      return customInstance<UserRead>(
+      {url: `/api/auth/users/${userId}/type`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: userUpdateType
+    },
+      );
+    }
+  /**
  * @summary Delete User
  */
 const deleteUserApiAuthUsersUserIdDelete = (
-    userId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<void>> => {
-    return axiosInstance.delete(
-      `/api/auth/users/${userId}`,options
-    );
-  }
-/**
+    userId: number,
+ ) => {
+      return customInstance<void>(
+      {url: `/api/auth/users/${userId}`, method: 'DELETE'
+    },
+      );
+    }
+  /**
  * Generate a password reset token for the given email.
  * @summary Forgot Password
  */
 const forgotPasswordApiAuthForgotPasswordPost = (
-    forgotPassword: ForgotPassword, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.post(
-      `/api/auth/forgot-password`,
-      forgotPassword,options
-    );
-  }
-/**
+    forgotPassword: ForgotPassword,
+ ) => {
+      return customInstance<unknown>(
+      {url: `/api/auth/forgot-password`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: forgotPassword
+    },
+      );
+    }
+  /**
  * Reset a user's password using a valid reset token.
  * @summary Reset Password
  */
 const resetPasswordApiAuthResetPasswordPost = (
-    resetPassword: ResetPassword, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.post(
-      `/api/auth/reset-password`,
-      resetPassword,options
-    );
-  }
-return {listUsersApiAuthUsersGet,registerApiAuthRegisterPost,loginApiAuthLoginPost,updateUserTypeApiAuthUsersUserIdTypePatch,deleteUserApiAuthUsersUserIdDelete,forgotPasswordApiAuthForgotPasswordPost,resetPasswordApiAuthResetPasswordPost}};
-export type ListUsersApiAuthUsersGetResult = AxiosResponse<UserRead[]>
-export type RegisterApiAuthRegisterPostResult = AxiosResponse<UserRead>
-export type LoginApiAuthLoginPostResult = AxiosResponse<Token>
-export type UpdateUserTypeApiAuthUsersUserIdTypePatchResult = AxiosResponse<UserRead>
-export type DeleteUserApiAuthUsersUserIdDeleteResult = AxiosResponse<void>
-export type ForgotPasswordApiAuthForgotPasswordPostResult = AxiosResponse<unknown>
-export type ResetPasswordApiAuthResetPasswordPostResult = AxiosResponse<unknown>
+    resetPassword: ResetPassword,
+ ) => {
+      return customInstance<unknown>(
+      {url: `/api/auth/reset-password`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: resetPassword
+    },
+      );
+    }
+  return {listUsersApiAuthUsersGet,registerApiAuthRegisterPost,loginApiAuthLoginPost,updateUserTypeApiAuthUsersUserIdTypePatch,deleteUserApiAuthUsersUserIdDelete,forgotPasswordApiAuthForgotPasswordPost,resetPasswordApiAuthResetPasswordPost}};
+
+type AwaitedInput<T> = PromiseLike<T> | T;
+
+    type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
+
+export type ListUsersApiAuthUsersGetResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['listUsersApiAuthUsersGet']>>>
+export type RegisterApiAuthRegisterPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['registerApiAuthRegisterPost']>>>
+export type LoginApiAuthLoginPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['loginApiAuthLoginPost']>>>
+export type UpdateUserTypeApiAuthUsersUserIdTypePatchResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['updateUserTypeApiAuthUsersUserIdTypePatch']>>>
+export type DeleteUserApiAuthUsersUserIdDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['deleteUserApiAuthUsersUserIdDelete']>>>
+export type ForgotPasswordApiAuthForgotPasswordPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['forgotPasswordApiAuthForgotPasswordPost']>>>
+export type ResetPasswordApiAuthResetPasswordPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['resetPasswordApiAuthResetPasswordPost']>>>

--- a/frontend/src/api/endpoints/default/default.ts
+++ b/frontend/src/api/endpoints/default/default.ts
@@ -5,25 +5,25 @@
  * Backend for the community litter reporting platform
  * OpenAPI spec version: 0.1.0
  */
-import axios from 'axios';
-import type {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
+import { customInstance } from '../../client';
 
 
 
-
-  export const getDefault = (axiosInstance: AxiosInstance = axios) => {
+  export const getDefault = () => {
 /**
  * @summary Root
  */
 const rootGet = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.get(
-      `/`,options
-    );
-  }
-return {}};
+    
+ ) => {
+      return customInstance<unknown>(
+      {url: `/`, method: 'GET'
+    },
+      );
+    }
+  return {}};
+
+type AwaitedInput<T> = PromiseLike<T> | T;
+
+    type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
+

--- a/frontend/src/api/endpoints/reports/reports.ts
+++ b/frontend/src/api/endpoints/reports/reports.ts
@@ -5,13 +5,6 @@
  * Backend for the community litter reporting platform
  * OpenAPI spec version: 0.1.0
  */
-import axios from 'axios';
-import type {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
-
 import type {
   BodyAddImageApiReportsReportIdImagesPost,
   BodyCreateReportApiReportsPost,
@@ -20,41 +13,43 @@ import type {
   ReportRead
 } from '../../model';
 
+import { customInstance } from '../../client';
 
 
 
-  export const getReports = (axiosInstance: AxiosInstance = axios) => {
+  export const getReports = () => {
 /**
  * Serve an uploaded image by filename.
  * @summary Serve Image
  */
 const serveImageApiReportsImagesFilenameGet = (
-    filename: string, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.get(
-      `/api/reports/images/${filename}`,options
-    );
-  }
-/**
+    filename: string,
+ ) => {
+      return customInstance<unknown>(
+      {url: `/api/reports/images/${filename}`, method: 'GET'
+    },
+      );
+    }
+  /**
  * List all reports, optionally filtered by status.
  * @summary List Reports
  */
 const listReportsApiReportsGet = (
-    params?: ListReportsApiReportsGetParams, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportRead[]>> => {
-    return axiosInstance.get(
-      `/api/reports/`,{
-    ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
-/**
+    params?: ListReportsApiReportsGetParams,
+ ) => {
+      return customInstance<ReportRead[]>(
+      {url: `/api/reports/`, method: 'GET',
+        params
+    },
+      );
+    }
+  /**
  * Create a new litter report with optional image uploads.
  * @summary Create Report
  */
 const createReportApiReportsPost = (
-    bodyCreateReportApiReportsPost: BodyCreateReportApiReportsPost, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportRead>> => {const formData = new FormData();
+    bodyCreateReportApiReportsPost: BodyCreateReportApiReportsPost,
+ ) => {const formData = new FormData();
 formData.append(`latitude`, bodyCreateReportApiReportsPost.latitude.toString())
 formData.append(`longitude`, bodyCreateReportApiReportsPost.longitude.toString())
 if(bodyCreateReportApiReportsPost.description !== undefined) {
@@ -67,76 +62,87 @@ if(bodyCreateReportApiReportsPost.images !== undefined) {
  bodyCreateReportApiReportsPost.images.forEach(value => formData.append(`images`, value));
  }
 
-    return axiosInstance.post(
-      `/api/reports/`,
-      formData,options
-    );
-  }
-/**
+      return customInstance<ReportRead>(
+      {url: `/api/reports/`, method: 'POST',
+       data: formData
+    },
+      );
+    }
+  /**
  * @summary Get Report
  */
 const getReportApiReportsReportIdGet = (
-    reportId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportRead>> => {
-    return axiosInstance.get(
-      `/api/reports/${reportId}`,options
-    );
-  }
-/**
+    reportId: number,
+ ) => {
+      return customInstance<ReportRead>(
+      {url: `/api/reports/${reportId}`, method: 'GET'
+    },
+      );
+    }
+  /**
  * Delete a report. Requires moderator or admin role.
  * @summary Delete Report
  */
 const deleteReportApiReportsReportIdDelete = (
-    reportId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<void>> => {
-    return axiosInstance.delete(
-      `/api/reports/${reportId}`,options
-    );
-  }
-/**
+    reportId: number,
+ ) => {
+      return customInstance<void>(
+      {url: `/api/reports/${reportId}`, method: 'DELETE'
+    },
+      );
+    }
+  /**
  * Upload an image and attach it to an existing report.
  * @summary Add Image
  */
 const addImageApiReportsReportIdImagesPost = (
     reportId: number,
-    bodyAddImageApiReportsReportIdImagesPost: BodyAddImageApiReportsReportIdImagesPost, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportImageRead>> => {const formData = new FormData();
+    bodyAddImageApiReportsReportIdImagesPost: BodyAddImageApiReportsReportIdImagesPost,
+ ) => {const formData = new FormData();
 formData.append(`image_type`, bodyAddImageApiReportsReportIdImagesPost.image_type);
 formData.append(`file`, bodyAddImageApiReportsReportIdImagesPost.file);
 
-    return axiosInstance.post(
-      `/api/reports/${reportId}/images`,
-      formData,options
-    );
-  }
-/**
+      return customInstance<ReportImageRead>(
+      {url: `/api/reports/${reportId}/images`, method: 'POST',
+       data: formData
+    },
+      );
+    }
+  /**
  * Mark a report as cleaned. Attaches the user id if authenticated.
  * @summary Mark Cleaned
  */
 const markCleanedApiReportsReportIdCleanPatch = (
-    reportId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportRead>> => {
-    return axiosInstance.patch(
-      `/api/reports/${reportId}/clean`,undefined,options
-    );
-  }
-/**
+    reportId: number,
+ ) => {
+      return customInstance<ReportRead>(
+      {url: `/api/reports/${reportId}/clean`, method: 'PATCH'
+    },
+      );
+    }
+  /**
  * Set a report back to pending. Requires moderator or admin role.
  * @summary Mark Unresolved
  */
 const markUnresolvedApiReportsReportIdUnresolvePatch = (
-    reportId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ReportRead>> => {
-    return axiosInstance.patch(
-      `/api/reports/${reportId}/unresolve`,undefined,options
-    );
-  }
-return {serveImageApiReportsImagesFilenameGet,listReportsApiReportsGet,createReportApiReportsPost,getReportApiReportsReportIdGet,deleteReportApiReportsReportIdDelete,addImageApiReportsReportIdImagesPost,markCleanedApiReportsReportIdCleanPatch,markUnresolvedApiReportsReportIdUnresolvePatch}};
-export type ServeImageApiReportsImagesFilenameGetResult = AxiosResponse<unknown>
-export type ListReportsApiReportsGetResult = AxiosResponse<ReportRead[]>
-export type CreateReportApiReportsPostResult = AxiosResponse<ReportRead>
-export type GetReportApiReportsReportIdGetResult = AxiosResponse<ReportRead>
-export type DeleteReportApiReportsReportIdDeleteResult = AxiosResponse<void>
-export type AddImageApiReportsReportIdImagesPostResult = AxiosResponse<ReportImageRead>
-export type MarkCleanedApiReportsReportIdCleanPatchResult = AxiosResponse<ReportRead>
-export type MarkUnresolvedApiReportsReportIdUnresolvePatchResult = AxiosResponse<ReportRead>
+    reportId: number,
+ ) => {
+      return customInstance<ReportRead>(
+      {url: `/api/reports/${reportId}/unresolve`, method: 'PATCH'
+    },
+      );
+    }
+  return {serveImageApiReportsImagesFilenameGet,listReportsApiReportsGet,createReportApiReportsPost,getReportApiReportsReportIdGet,deleteReportApiReportsReportIdDelete,addImageApiReportsReportIdImagesPost,markCleanedApiReportsReportIdCleanPatch,markUnresolvedApiReportsReportIdUnresolvePatch}};
+
+type AwaitedInput<T> = PromiseLike<T> | T;
+
+    type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
+
+export type ServeImageApiReportsImagesFilenameGetResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['serveImageApiReportsImagesFilenameGet']>>>
+export type ListReportsApiReportsGetResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['listReportsApiReportsGet']>>>
+export type CreateReportApiReportsPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['createReportApiReportsPost']>>>
+export type GetReportApiReportsReportIdGetResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['getReportApiReportsReportIdGet']>>>
+export type DeleteReportApiReportsReportIdDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['deleteReportApiReportsReportIdDelete']>>>
+export type AddImageApiReportsReportIdImagesPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['addImageApiReportsReportIdImagesPost']>>>
+export type MarkCleanedApiReportsReportIdCleanPatchResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['markCleanedApiReportsReportIdCleanPatch']>>>
+export type MarkUnresolvedApiReportsReportIdUnresolvePatchResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getReports>['markUnresolvedApiReportsReportIdUnresolvePatch']>>>

--- a/frontend/src/api/endpoints/volunteers/volunteers.ts
+++ b/frontend/src/api/endpoints/volunteers/volunteers.ts
@@ -5,37 +5,38 @@
  * Backend for the community litter reporting platform
  * OpenAPI spec version: 0.1.0
  */
-import axios from 'axios';
-import type {
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
+import { customInstance } from '../../client';
 
 
 
-
-  export const getVolunteers = (axiosInstance: AxiosInstance = axios) => {
+  export const getVolunteers = () => {
 /**
  * @summary List Volunteers
  */
 const listVolunteersApiVolunteersGet = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.get(
-      `/api/volunteers/`,options
-    );
-  }
-/**
+    
+ ) => {
+      return customInstance<unknown>(
+      {url: `/api/volunteers/`, method: 'GET'
+    },
+      );
+    }
+  /**
  * @summary Claim Report
  */
 const claimReportApiVolunteersClaimReportIdPost = (
-    reportId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    return axiosInstance.post(
-      `/api/volunteers/claim/${reportId}`,undefined,options
-    );
-  }
-return {listVolunteersApiVolunteersGet,claimReportApiVolunteersClaimReportIdPost}};
-export type ListVolunteersApiVolunteersGetResult = AxiosResponse<unknown>
-export type ClaimReportApiVolunteersClaimReportIdPostResult = AxiosResponse<unknown>
+    reportId: number,
+ ) => {
+      return customInstance<unknown>(
+      {url: `/api/volunteers/claim/${reportId}`, method: 'POST'
+    },
+      );
+    }
+  return {listVolunteersApiVolunteersGet,claimReportApiVolunteersClaimReportIdPost}};
+
+type AwaitedInput<T> = PromiseLike<T> | T;
+
+    type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
+
+export type ListVolunteersApiVolunteersGetResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getVolunteers>['listVolunteersApiVolunteersGet']>>>
+export type ClaimReportApiVolunteersClaimReportIdPostResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getVolunteers>['claimReportApiVolunteersClaimReportIdPost']>>>

--- a/frontend/src/components/ReportPopup.jsx
+++ b/frontend/src/components/ReportPopup.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Popup } from 'react-leaflet'
 import { reverseGeocode } from '../api/geocode'
+import { API_BASE_URL } from '../api/client'
 
 function getPopupImage(report) {
   const images = report.images || []
@@ -36,7 +37,7 @@ export default function ReportPopup({ report }) {
         {/* Image */}
         {image ? (
           <img
-            src={`/api/reports/images/${image.url}`}
+            src={`${API_BASE_URL}/api/reports/images/${image.url}`}
             alt="Report"
             style={{ width: '100%', height: '120px', objectFit: 'cover', borderRadius: '4px', marginBottom: '8px' }}
           />

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useMemo } from 'react'
-import axios from 'axios'
+import api from '../api/client'
 
 const AuthContext = createContext(null)
 
@@ -18,7 +18,7 @@ export function AuthProvider({ children }) {
   const user = useMemo(() => (token ? decodeToken(token) : null), [token])
 
   const login = async (email, password) => {
-    const res = await axios.post('/api/auth/login', { email, password })
+    const res = await api.post('/api/auth/login', { email, password })
     const t = res.data.access_token
     localStorage.setItem('token', t)
     setToken(t)
@@ -26,7 +26,7 @@ export function AuthProvider({ children }) {
   }
 
   const register = async (email, fullName, password) => {
-    const res = await axios.post('/api/auth/register', {
+    const res = await api.post('/api/auth/register', {
       email,
       full_name: fullName,
       password
@@ -35,12 +35,12 @@ export function AuthProvider({ children }) {
   }
 
   const forgotPassword = async (email) => {
-    const res = await axios.post('/api/auth/forgot-password', { email })
+    const res = await api.post('/api/auth/forgot-password', { email })
     return res.data
   }
 
   const resetPassword = async (resetToken, newPassword) => {
-    const res = await axios.post('/api/auth/reset-password', {
+    const res = await api.post('/api/auth/reset-password', {
       token: resetToken,
       new_password: newPassword
     })

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link, Navigate } from 'react-router-dom'
-import axios from 'axios'
+import api from '../api/client'
 import { getReports } from '../api/endpoints/reports/reports'
 import { useAuth } from '../context/AuthContext'
 
@@ -19,7 +19,7 @@ export default function Admin() {
   const fetchReports = () => {
     setLoading(true)
     listReportsApiReportsGet(statusFilter ? { status: statusFilter } : undefined)
-      .then(res => setReports(res.data))
+      .then(data => setReports(data))
       .catch(() => setReports([]))
       .finally(() => setLoading(false))
   }
@@ -30,7 +30,7 @@ export default function Admin() {
     if (!confirm(`Are you sure you want to delete report #${reportId}?`)) return
     setDeletingId(reportId)
     try {
-      await axios.delete(`/api/reports/${reportId}`, {
+      await api.delete(`/api/reports/${reportId}`, {
         headers: { Authorization: `Bearer ${token}` }
       })
       setReports(prev => prev.filter(r => r.id !== reportId))

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -14,13 +14,12 @@ export default function Home() {
     Promise.all([
       listReportsApiReportsGet(),
       listVolunteersApiVolunteersGet()
-    ]).then(([reportsRes, volunteersRes]) => {
-      const data = reportsRes.data
-      setReports(data)
+    ]).then(([reportsData, volunteersData]) => {
+      setReports(reportsData)
       setStats({
-        reports: data.length,
-        cleaned: data.filter(r => r.status === 'cleaned').length,
-        volunteers: Array.isArray(volunteersRes.data) ? volunteersRes.data.length : 0
+        reports: reportsData.length,
+        cleaned: reportsData.filter(r => r.status === 'cleaned').length,
+        volunteers: Array.isArray(volunteersData) ? volunteersData.length : 0
       })
     }).catch(console.error)
   }, [])

--- a/frontend/src/pages/MapView.jsx
+++ b/frontend/src/pages/MapView.jsx
@@ -14,7 +14,7 @@ export default function MapView() {
 
   useEffect(() => {
     listReportsApiReportsGet()
-      .then(res => setReports(res.data))
+      .then(data => setReports(data))
       .catch(console.error)
   }, [])
 

--- a/frontend/src/pages/ReportDetail.jsx
+++ b/frontend/src/pages/ReportDetail.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { MapContainer, TileLayer, Marker } from 'react-leaflet'
-import axios from 'axios'
+import api, { API_BASE_URL } from '../api/client'
 import { reverseGeocode } from '../api/geocode'
 import { useAuth } from '../context/AuthContext'
 
@@ -27,7 +27,7 @@ export default function ReportDetail() {
   const authHeaders = token ? { Authorization: `Bearer ${token}` } : {}
 
   const fetchReport = () => {
-    axios.get(`/api/reports/${id}`)
+    api.get(`/api/reports/${id}`)
       .then(res => {
         setReport(res.data)
         return reverseGeocode(res.data.latitude, res.data.longitude)
@@ -43,7 +43,7 @@ export default function ReportDetail() {
   const resolvedImages = report?.images?.filter(img => img.image_type === 'resolved') || []
   const allPhotos = [...reportImages, ...resolvedImages]
 
-  const imageUrl = (img) => `/api/reports/images/${img.url}`
+  const imageUrl = (img) => `${API_BASE_URL}/api/reports/images/${img.url}`
 
   const handleResolvePhotos = (e) => {
     const files = Array.from(e.target.files)
@@ -84,13 +84,13 @@ export default function ReportDetail() {
         const formData = new FormData()
         formData.append('file', file)
         formData.append('image_type', 'resolved')
-        await axios.post(`/api/reports/${id}/images`, formData, {
+        await api.post(`/api/reports/${id}/images`, formData, {
           headers: { 'Content-Type': 'multipart/form-data', ...authHeaders }
         })
       }
 
       // Mark as cleaned
-      const res = await axios.patch(`/api/reports/${id}/clean`, undefined, {
+      const res = await api.patch(`/api/reports/${id}/clean`, undefined, {
         headers: authHeaders
       })
       setReport(res.data)
@@ -110,7 +110,7 @@ export default function ReportDetail() {
 
   const handleUnresolve = async () => {
     try {
-      const res = await axios.patch(`/api/reports/${id}/unresolve`, undefined, {
+      const res = await api.patch(`/api/reports/${id}/unresolve`, undefined, {
         headers: authHeaders
       })
       setReport(res.data)
@@ -123,7 +123,7 @@ export default function ReportDetail() {
     if (!confirm('Are you sure you want to delete this report? This cannot be undone.')) return
     setDeleting(true)
     try {
-      await axios.delete(`/api/reports/${id}`, { headers: authHeaders })
+      await api.delete(`/api/reports/${id}`, { headers: authHeaders })
       navigate('/admin')
     } catch {
       alert('Failed to delete report.')

--- a/frontend/src/pages/ReportLitter.jsx
+++ b/frontend/src/pages/ReportLitter.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
-import axios from 'axios'
+import api from '../api/client'
 import LocationPicker from '../components/LocationPicker'
 import { autosuggest } from '../api/w3w'
 import { useAuth } from '../context/AuthContext'
@@ -100,7 +100,7 @@ export default function ReportLitter() {
       const headers = { 'Content-Type': 'multipart/form-data' }
       if (token) headers['Authorization'] = `Bearer ${token}`
 
-      const res = await axios.post('/api/reports/', formData, { headers })
+      const res = await api.post('/api/reports/', formData, { headers })
       setSubmittedReportId(res.data.id)
     } catch (err) {
       alert('Failed to submit report. Please try again.')

--- a/frontend/src/pages/UserManagement.jsx
+++ b/frontend/src/pages/UserManagement.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Navigate } from 'react-router-dom'
-import axios from 'axios'
+import api from '../api/client'
 import { useAuth } from '../context/AuthContext'
 
 const ROLES = ['superuser', 'admin', 'moderator', 'volunteer']
@@ -16,7 +16,7 @@ export default function UserManagement() {
 
   useEffect(() => {
     if (!token) return
-    axios.get('/api/auth/users', authHeaders)
+    api.get('/api/auth/users', authHeaders)
       .then(res => setUsers(res.data))
       .catch(() => setError('Failed to load users.'))
       .finally(() => setLoading(false))
@@ -29,7 +29,7 @@ export default function UserManagement() {
     setUpdating(userId)
     setError('')
     try {
-      const res = await axios.patch(
+      const res = await api.patch(
         `/api/auth/users/${userId}/type`,
         { user_type: newRole },
         authHeaders
@@ -47,7 +47,7 @@ export default function UserManagement() {
     if (!confirm(`Are you sure you want to delete user ${email}?`)) return
     setError('')
     try {
-      await axios.delete(`/api/auth/users/${userId}`, authHeaders)
+      await api.delete(`/api/auth/users/${userId}`, authHeaders)
       setUsers(prev => prev.filter(u => u.id !== userId))
     } catch (err) {
       const detail = err.response?.data?.detail

--- a/frontend/src/pages/VolunteerDashboard.jsx
+++ b/frontend/src/pages/VolunteerDashboard.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Link, Navigate } from 'react-router-dom'
 import { getReports } from '../api/endpoints/reports/reports'
 import { useAuth } from '../context/AuthContext'
+import { API_BASE_URL } from '../api/client'
 
 const { listReportsApiReportsGet } = getReports()
 
@@ -15,7 +16,7 @@ export default function VolunteerDashboard() {
     if (tab === 'unresolved') {
       setLoading(true)
       listReportsApiReportsGet({ status: 'pending' })
-        .then(res => setPendingReports(res.data))
+        .then(data => setPendingReports(data))
         .catch(() => setPendingReports([]))
         .finally(() => setLoading(false))
     }
@@ -102,7 +103,7 @@ export default function VolunteerDashboard() {
                     <div className="w-24 h-24 flex-shrink-0 bg-gray-100">
                       {firstImage ? (
                         <img
-                          src={`/api/reports/images/${firstImage.url}`}
+                          src={`${API_BASE_URL}/api/reports/images/${firstImage.url}`}
                           alt=""
                           className="w-full h-full object-cover"
                         />

--- a/proxy-conf/api.mapthemess.uk
+++ b/proxy-conf/api.mapthemess.uk
@@ -1,0 +1,1 @@
+client_max_body_size 50m;

--- a/push-images.sh
+++ b/push-images.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+DOCKERHUB_USER="max246"
+PROJECT="map-the-mess"
+
+echo "Building images..."
+docker compose build --build-arg VITE_API_URL=https://api.mapthemess.uk
+
+echo "Tagging images..."
+docker tag ${PROJECT}-backend ${DOCKERHUB_USER}/${PROJECT}-backend:latest
+docker tag ${PROJECT}-frontend ${DOCKERHUB_USER}/${PROJECT}-frontend:latest
+
+echo "Pushing images..."
+docker push ${DOCKERHUB_USER}/${PROJECT}-backend:latest
+docker push ${DOCKERHUB_USER}/${PROJECT}-frontend:latest
+
+echo "Done!"


### PR DESCRIPTION
  - Add docker-compose.prod.yml with nginx-proxy and Let's Encrypt auto-SSL for mapthemess.uk (frontend) and api.mapthemess.uk (backend)
  - Add push-images.sh script to build, tag, and push images to Docker Hub (max246/map-the-mess-frontend, max246/map-the-mess-backend)
  - Configure frontend to use VITE_API_URL env var for environment-specific API base URL (.env.development / .env.production)
  - Update all frontend pages and components to use the shared axios client instead of bare axios imports, fixing API routing in production
  - Configure Orval to use a custom axios mutator so generated API endpoints respect the base URL
  - Add CORS origins for mapthemess.uk in the backend
  - Add client_max_body_size 50m nginx config for image uploads via proxy-conf/
  - Add .env.example template and gitignore .env.* files and .pem files
  - Update README with full deployment docs, architecture diagram, and setup instructions
