### PR TITLE
Add release auto upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Build and Push Docker Images
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: |
+            max246/map-the-mess-backend:latest
+            max246/map-the-mess-backend:${{ github.event.release.tag_name }}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          build-args: |
+            VITE_API_URL=https://api.mapthemess.uk
+          tags: |
+            max246/map-the-mess-frontend:latest
+            max246/map-the-mess-frontend:${{ github.event.release.tag_name }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,20 @@
+# Development Guide
+
+## CI/CD: Automated Docker Image Releases
+
+When you publish a GitHub release from `main`, a GitHub Actions workflow automatically builds and pushes Docker images to Docker Hub, tagged as both `latest` and the release tag (e.g. `v1.0.0`).
+
+### Setup (one-time)
+
+1. Create a Docker Hub access token at https://hub.docker.com/settings/security (Read & Write permissions)
+2. Add these secrets to your GitHub repo under **Settings → Secrets and variables → Actions**:
+   - `DOCKERHUB_USERNAME` — your Docker Hub username 
+   - `DOCKERHUB_TOKEN` — the access token from step 1
+
+### How it works
+
+- The workflow is defined in `.github/workflows/release.yml`
+- It triggers on release publish events
+- Builds both `max246/map-the-mess-backend` and `max246/map-the-mess-frontend` images
+- Pushes them to Docker Hub with two tags: `latest` and the release tag
+- The frontend build passes `VITE_API_URL=https://api.mapthemess.uk` as a build argument

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,13 +7,17 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - ./data/pgdata:/var/lib/postgresql/data
     ports:
       - "5433:5432"
 
   backend:
     image: max246/map-the-mess-backend:latest
     restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    volumes:
+      - ./data/images:/app/images
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: ${SECRET_KEY}
@@ -29,6 +33,8 @@ services:
   frontend:
     image: max246/map-the-mess-frontend:latest
     restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     environment:
       VIRTUAL_HOST: mapthemess.uk
       VIRTUAL_PORT: "80"
@@ -63,8 +69,35 @@ services:
     environment:
       DEFAULT_EMAIL: ${SUPERUSER_EMAIL}
 
+  db-backup:
+    image: prodrigestivill/postgres-backup-local:16
+    restart: unless-stopped
+    volumes:
+      - ./data/db-backups:/backups
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      SCHEDULE: "@hourly"
+      BACKUP_KEEP_HOURS: "24"
+      BACKUP_KEEP_DAYS: "7"
+      BACKUP_KEEP_WEEKS: "4"
+      HEALTHCHECK_PORT: "8080"
+    depends_on:
+      - db
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      WATCHTOWER_LABEL_ENABLE: "true"
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_POLL_INTERVAL: "300"
+
 volumes:
-  pgdata:
   certs:
   vhost:
   html:


### PR DESCRIPTION
  Summary
                                                                                                                                                                                                                                    
  - Add GitHub Actions workflow to automatically build and push Docker images to Docker Hub when a release is published, tagged as both latest and the release tag                                                                  
  - Add Watchtower to production compose for automatic container updates when new images are pushed
  - Add scheduled PostgreSQL backups (hourly) with configurable retention using postgres-backup-local
  - Persist backend uploaded images via bind mount (./data/images) — previously these were lost on container recreate
  - Move all persistent data (pgdata, images, db-backups) from Docker volumes to local bind mounts under ./data/ for easier backup and visibility
  - Add DEVELOPMENT.md documenting the CI/CD setup and required Docker Hub secrets

  Test plan

  - Verify GitHub Actions workflow triggers on release publish
  - Confirm DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets are configured in the repo
  - Verify Watchtower only updates backend and frontend containers (label-scoped)
  - Confirm ./data/ subdirectories are created automatically on first deploy
  - Verify db-backup container produces hourly dumps in ./data/db-backups
  - Confirm uploaded images persist across backend container restarts