### PR TITLE
Fix limit upload endpoint

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ When a PR is merged into the `develop` branch, a GitHub Actions workflow automat
 - The workflow is defined in `.github/workflows/develop.yml`
 - It triggers on every push to `develop`
 - Builds both images with the `develop` tag (e.g. `max246/map-the-mess-backend:develop`)
-- The frontend is built with `VITE_API_URL=https://api.dev.mapthemess.uk`
+- The frontend is built with an empty `VITE_API_URL` (uses relative URLs via the frontend nginx proxy)
 - The backend version is set to `develop-<commit-sha>`
 - Watchtower on the dev EC2 auto-pulls new images within 5 minutes
 
@@ -42,9 +42,21 @@ When a PR is merged into the `develop` branch, a GitHub Actions workflow automat
 
 ### DNS
 
-Add two A records in Route 53 pointing to the dev EC2 Elastic IP:
+Add an A record in Route 53 pointing to the dev EC2 Elastic IP:
 
-| Type | Name                    | Value              |
-|------|-------------------------|--------------------|
-| A    | `dev.mapthemess.uk`     | Dev EC2 Elastic IP |
-| A    | `api.dev.mapthemess.uk` | Dev EC2 Elastic IP |
+| Type | Name                | Value              |
+|------|---------------------|--------------------|
+| A    | `dev.mapthemess.uk` | Dev EC2 Elastic IP |
+
+## Nginx Proxy Configuration
+
+Upload size limits are configured at two levels:
+
+1. **Frontend nginx** (`frontend/nginx.conf`) — `client_max_body_size 50m` for proxying to the backend
+2. **nginx-proxy** (per-vhost config in `proxy-conf/`) — `client_max_body_size 50m` to allow large uploads through the reverse proxy
+
+Per-vhost config files in `proxy-conf/` are mounted into the nginx-proxy container:
+- `proxy-conf/mapthemess.uk` — production
+- `proxy-conf/dev.mapthemess.uk` — dev
+
+If you get `413 Content Too Large` errors, check both levels are configured.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - certs:/etc/nginx/certs
       - vhost:/etc/nginx/vhost.d
+      - ./proxy-conf/dev.mapthemess.uk:/etc/nginx/vhost.d/dev.mapthemess.uk:ro
       - html:/usr/share/nginx/html
     environment:
       TRUST_DOWNSTREAM_PROXY: "false"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - certs:/etc/nginx/certs
       - vhost:/etc/nginx/vhost.d
+      - ./proxy-conf/mapthemess.uk:/etc/nginx/vhost.d/mapthemess.uk:ro
       - html:/usr/share/nginx/html
     environment:
       TRUST_DOWNSTREAM_PROXY: "false"

--- a/proxy-conf/dev.mapthemess.uk
+++ b/proxy-conf/dev.mapthemess.uk
@@ -1,0 +1,1 @@
+client_max_body_size 50m;

--- a/proxy-conf/mapthemess.uk
+++ b/proxy-conf/mapthemess.uk
@@ -1,0 +1,1 @@
+client_max_body_size 50m;


### PR DESCRIPTION
Endpoint was limited how big the image would be.

This would fail the endpoint and not able to create the report